### PR TITLE
Update Build .NET SDK to 5.0

### DIFF
--- a/src/pages/Build.vue
+++ b/src/pages/Build.vue
@@ -15,7 +15,7 @@
                         <p>
                           Download NET Core
                           <a
-                            href="https://dotnet.microsoft.com/download/dotnet-core/3.1"
+                            href="https://dotnet.microsoft.com/download/dotnet/5.0"
                             rel="noopener"
                             target="_blank"
                           >here</a>. Then install the SDK.


### PR DESCRIPTION
Now the Ryujinx is compiled against .NET 5.0, the "How to Build" section needs to be updated to point users to the proper SDK download page.