### PR TITLE
Disable macOS downloads

### DIFF
--- a/src/components/DownloadButton.vue
+++ b/src/components/DownloadButton.vue
@@ -6,6 +6,7 @@
                 class="mx-2"
                 dark
                 :color="`ryu_${color}`"
+                :disabled="disabled"
                 target="_blank"
                 rel="noopener"
                 :loading="loading"
@@ -27,7 +28,8 @@ export default {
         loading: Boolean,
         href: String,
         version: String,
-        click: Function
+        click: Function,
+        disabled: Boolean
     }
 }
 </script>

--- a/src/pages/Download.vue
+++ b/src/pages/Download.vue
@@ -37,6 +37,7 @@
                           color="orange"
                           platform="windows"
                           :version="version"
+                          disabled="false"
                           :href="`${downloadURL}-win_x64.zip`"
                           :click="trackDownload"
                           :loading="isLoading"
@@ -45,6 +46,7 @@
                         <DownloadButton
                           color="orange"
                           platform="linux"
+                          disabled="false"
                           :version="version"
                           :href="`${downloadURL}-linux_x64.tar.gz`"
                           :click="trackDownload"
@@ -54,7 +56,8 @@
                         <DownloadButton
                           color="orange"
                           platform="apple"
-                          :version="version"
+                          disabled="true"
+                          :version="Coming soon"
                           :href="`${downloadURL}-osx_x64.zip`"
                           :click="trackDownload"
                           :loading="isLoading"


### PR DESCRIPTION
Disabled the button for macOS downloads and edited the tooltip to say "Coming soon".

This should prevent people from wasting time downloading the client, then going to the discord only to find out it is non-functional.


**please note: I've never written using vue.js  so I have no idea if what I've changed is actually correct. I only inferred what needed to be done based on the context of everything else in the file and a quick google search**