### PR TITLE
Move reference of LDN servers to web hosting line

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ If you'd like to support the project financially, Ryujinx has an active Patreon 
     <img alt="patreon" src="https://images.squarespace-cdn.com/content/v1/560c1d39e4b0b4fae0c9cf2a/1567548955044-WVD994WZP76EWF15T0L3/Patreon+Button.png?format=500w" width="150">
 </a>
 
-All the developers working on the project do so on their free time, but the project has several expenses:
+All developers working on the project do so in their free time, but the project has several expenses:
 * Hackable Nintendo Switch consoles to reverse-engineer the hardware
 * Additional computer hardware for testing purposes (e.g. GPUs to diagnose graphical bugs, etc.)
-* Licenses for various software development tools (e.g. Jetbrains, LDN servers, IDA)
-* Web hosting and infrastructure maintenance
+* Licenses for various software development tools (e.g. Jetbrains, IDA)
+* Web hosting and infrastructure maintenance (e.g. LDN servers)
 
 All funds received through Patreon are considered a donation to support the project. Patrons receive early access to progress reports and exclusive access to developer interviews.
 


### PR DESCRIPTION
Moved "LDN servers" out of the development tools line and into the web hosting and infrastructure maintenance line. Also cleaned up some grammar.