### PR TITLE
Change macOS minimum version to 12

### DIFF
--- a/src/i18n/locales/en/views/download.json
+++ b/src/i18n/locales/en/views/download.json
@@ -8,7 +8,7 @@
   "supportPlanned": "Support planned",
   "supportWindows": "For Windows 10 & 11",
   "supportLinux": "For the most common Linux distros",
-  "supportMacOS": "For macOS 11 and later (Intel and Apple Silicon)",
+  "supportMacOS": "For macOS 12 and later (Intel and Apple Silicon)",
   "buildInformation": "Build information",
   "buildRelease": "This build was released on {0}",
   "assets": "assets",


### PR DESCRIPTION
The Ryujinx app has already been bumped to 12.

Edit: See [here](https://github.com/Ryujinx/Ryujinx/pull/5925) for details. 