### PR TITLE
Fix Crowdin link in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Future languages to be added:
 - Portuguese
 - Spanish
 
-Follow this link to participate in the translation (via Crowdin): https://crwd.in/ryujinx-website-ryujinxorg
+Follow this link to participate in the translation (via Crowdin): <https://crowdin.com/project/ryujinx-website-ryujinxorg>
 
 ### Development
 


### PR DESCRIPTION
Things added/changed:

- Fix Crowdin link in the readme.
  - The previous link led to <https://crowdin.com/project/ryujinx-website-ryujinxorg/invite>
